### PR TITLE
fix: unblock Go lint by removing unused helpers

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -690,20 +690,6 @@ func writeError(w http.ResponseWriter, status int, format string, args ...any) {
 	})
 }
 
-func firstHeaderValue(r *http.Request, keys ...string) string {
-	for _, key := range keys {
-		if v := r.Header.Get(key); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-func tenantContextFromRequest(r *http.Request) string {
-	tenant, _ := tenantContextFromRequestValidated(r)
-	return tenant
-}
-
 func tenantContextFromRequestValidated(r *http.Request) (string, error) {
 	vaolTenant := strings.TrimSpace(r.Header.Get("X-VAOL-Tenant-ID"))
 	legacyTenant := strings.TrimSpace(r.Header.Get("X-Tenant-ID"))


### PR DESCRIPTION
## Summary
- remove unused `firstHeaderValue` helper
- remove unused `tenantContextFromRequest` wrapper
- keep tenant validation path via `tenantContextFromRequestValidated` unchanged

## Why
Mainline CI run `22284880714` failed in `Lint (Go)` with `unused` errors in `pkg/api/handlers.go`.

## Validation
- `go test ./...`
- `$(go env GOPATH)/bin/golangci-lint run` (v1.64.8)
