### PR TITLE
chore(ci): add workflow pin policy guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ permissions:
   contents: read
 
 jobs:
+  workflow-pin-policy:
+    name: Workflow Pin Policy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check_workflow_pins.sh
+
   toolchain-guard:
     name: Toolchain Guard (Go)
     runs-on: ubuntu-24.04

--- a/.github/workflows/ghcr-smoke.yml
+++ b/.github/workflows/ghcr-smoke.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   smoke:
     name: GHCR Pull + Runtime Smoke
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/check_workflow_pins.sh
+++ b/scripts/check_workflow_pins.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW_DIR="${1:-${ROOT_DIR}/.github/workflows}"
+
+if [[ ! -d "${WORKFLOW_DIR}" ]]; then
+  echo "workflow directory not found: ${WORKFLOW_DIR}" >&2
+  exit 2
+fi
+
+violations=0
+
+check_policy() {
+  local pattern="$1"
+  local message="$2"
+  local matches
+  matches="$(rg -n --glob '*.yml' "${pattern}" "${WORKFLOW_DIR}" || true)"
+  if [[ -n "${matches}" ]]; then
+    echo "policy violation: ${message}" >&2
+    echo "${matches}" >&2
+    echo >&2
+    violations=1
+  fi
+}
+
+check_policy 'runs-on:\s*ubuntu-latest\b' "use pinned runner image (ubuntu-24.04), not ubuntu-latest"
+check_policy 'uses:\s*[^[:space:]]+@master\b' "do not reference @master in workflow actions"
+check_policy '(^|[[:space:]])version:\s*latest\b' "do not use version: latest in workflow configuration"
+check_policy 'go install [^[:space:]]+@latest\b' "do not install Go tools using @latest"
+
+if [[ "${violations}" -ne 0 ]]; then
+  echo "workflow pin policy check failed" >&2
+  exit 1
+fi
+
+echo "workflow pin policy check passed (${WORKFLOW_DIR})"


### PR DESCRIPTION
## Summary
Add a CI policy guard that blocks floating workflow references from being introduced again.

## Changes
1. Added `scripts/check_workflow_pins.sh` policy script that fails on:
   - `runs-on: ubuntu-latest`
   - `uses: ...@master`
   - `version: latest`
   - `go install ...@latest`
2. Added new CI job `Workflow Pin Policy` in `.github/workflows/ci.yml` to run this script on every push/PR.
3. Updated `.github/workflows/ghcr-smoke.yml` runner to `ubuntu-24.04` so current workflows satisfy policy.

## Validation
- `./scripts/check_workflow_pins.sh`
- `bash -n scripts/check_workflow_pins.sh`
- `go test ./...`
