### PR TITLE
chore(ci): pin all workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     name: Workflow Pin Policy
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - run: ./scripts/check_workflow_pins.sh
 
   toolchain-guard:
     name: Toolchain Guard (Go)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - run: ./scripts/check_go_toolchain.sh
 
   lint-go:
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [toolchain-guard]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
           version: v1.64.8
 
@@ -41,8 +41,8 @@ jobs:
     name: Lint (Python)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
       - run: cd sdk/python && pip install -e ".[dev]" cryptography
@@ -54,8 +54,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [toolchain-guard]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - run: go test -race -cover ./...
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [toolchain-guard]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - run: go test -race ./tests/e2e ./tests/tamper -v
@@ -75,8 +75,8 @@ jobs:
     name: Test (Python)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
       - run: cd sdk/python && pip install -e ".[dev]" cryptography && pytest tests/ -v
@@ -85,8 +85,8 @@ jobs:
     name: Test (TypeScript)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
       - run: cd sdk/typescript && npm ci && npm test
@@ -95,8 +95,8 @@ jobs:
     name: Lint (TypeScript)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: "20"
       - run: cd sdk/typescript && npm ci && npm run lint
@@ -105,8 +105,8 @@ jobs:
     name: Test (OPA Policies)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: open-policy-agent/setup-opa@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: open-policy-agent/setup-opa@34a30e8a924d1b03ce2cf7abe97250bbb1f332b5
         with:
           version: 1.13.2
       - run: opa test policies/ -v
@@ -116,12 +116,12 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [toolchain-guard]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - run: go test -bench=. -benchmem -count=1 ./pkg/merkle/... ./pkg/signer/... ./pkg/record/... | tee bench-results.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: benchmark-results
           path: bench-results.txt
@@ -131,15 +131,15 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [toolchain-guard]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - run: go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
       - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - run: gosec -quiet -exclude=G104,G117,G204,G304,G306,G704 -exclude-dir=gen ./...
       - run: govulncheck ./...
-      - uses: aquasecurity/trivy-action@0.34.1
+      - uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518
         with:
           scan-type: fs
           scan-ref: .
@@ -151,13 +151,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: anchore/sbom-action@v0.22.2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad
         with:
           path: .
           format: spdx-json
           output-file: sbom.spdx.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: sbom-spdx
           path: sbom.spdx.json
@@ -167,8 +167,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [test-go, test-e2e-tamper, security]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - run: go build ./cmd/vaol-server
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - run: docker build -f deploy/docker/Dockerfile.server -t vaol-server:ci .
       - run: docker build -f deploy/docker/Dockerfile.proxy -t vaol-proxy:ci .
 
@@ -189,8 +189,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - name: Run reproducible auditor demo
@@ -209,7 +209,7 @@ jobs:
           jq -e '.title and .bundle and (.bundle.results | type == "array")' "${ARTIFACT_DIR}/verify-report.json" >/dev/null
       - name: Upload auditor demo artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: auditor-demo-artifacts
           path: |

--- a/.github/workflows/ghcr-smoke.yml
+++ b/.github/workflows/ghcr-smoke.yml
@@ -21,7 +21,7 @@ jobs:
     name: GHCR Pull + Runtime Smoke
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
         run: echo "Using TAG=${TAG}"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,38 +17,38 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.24.13"
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           version: v2.14.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Attest Release Artifacts
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
         if: ${{ !(github.event.repository.private && github.event.repository.owner.type == 'User') }}
         with:
           subject-path: "dist/*"
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0.22.2
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad
         with:
           path: .
           format: spdx-json
           output-file: sbom.spdx.json
           upload-release-assets: true
       - name: Upload SBOM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-sbom-spdx
           path: sbom.spdx.json

--- a/scripts/check_workflow_pins.sh
+++ b/scripts/check_workflow_pins.sh
@@ -29,6 +29,15 @@ check_policy 'uses:\s*[^[:space:]]+@master\b' "do not reference @master in workf
 check_policy '(^|[[:space:]])version:\s*latest\b' "do not use version: latest in workflow configuration"
 check_policy 'go install [^[:space:]]+@latest\b' "do not install Go tools using @latest"
 
+unpinned_uses="$(rg -n --glob '*.yml' '^\s*-\s*uses:\s*[^[:space:]]+@[^[:space:]]+' "${WORKFLOW_DIR}" || true)"
+unpinned_uses="$(printf "%s\n" "${unpinned_uses}" | rg -v '@[0-9a-f]{40}(\s|$)' || true)"
+if [[ -n "${unpinned_uses}" ]]; then
+  echo "policy violation: workflow actions must be pinned to 40-character commit SHA refs" >&2
+  echo "${unpinned_uses}" >&2
+  echo >&2
+  violations=1
+fi
+
 if [[ "${violations}" -ne 0 ]]; then
   echo "workflow pin policy check failed" >&2
   exit 1


### PR DESCRIPTION
## Summary
Pin all GitHub Actions references in workflows to immutable commit SHAs and tighten the existing workflow pin policy guard to enforce SHA-pinned action refs.

## Changes
1. Converted all `uses: owner/repo@tag` refs to commit SHAs in:
   - `.github/workflows/ci.yml`
   - `.github/workflows/release.yml`
   - `.github/workflows/ghcr-smoke.yml`
2. Updated `scripts/check_workflow_pins.sh` to fail if any remote action is not pinned to a 40-hex SHA.

## Validation
- `./scripts/check_workflow_pins.sh`
- `go test ./...`

## Notes
- This keeps the existing protections (`ubuntu-24.04`, no `version: latest`, no `go install ...@latest`) and adds immutable action-source enforcement.
