### PR TITLE
feat(verification): enforce profiles and publish release auditor evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,31 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Auditor Evidence Demo
+        env:
+          VAOL_DEMO_KEEP_STACK: "0"
+          VAOL_DEMO_RESET_STATE: "1"
+        run: ./scripts/demo_auditor.sh
+      - name: Package Auditor Evidence Bundle
+        run: |
+          set -euo pipefail
+          RUN_DIR="$(ls -1dt tmp/demo-auditor/* | head -n 1)"
+          ARTIFACT_DIR="${RUN_DIR}/artifacts"
+          test -d "${ARTIFACT_DIR}"
+          ARCHIVE="auditor-evidence-${GITHUB_REF_NAME}.tar.gz"
+          tar -C "${RUN_DIR}" -czf "${ARCHIVE}" artifacts
+          echo "AUDITOR_EVIDENCE_ARCHIVE=${ARCHIVE}" >> "${GITHUB_ENV}"
+      - name: Upload Auditor Evidence Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: auditor-evidence-${{ github.ref_name }}
+          path: |
+            ${{ env.AUDITOR_EVIDENCE_ARCHIVE }}
+            tmp/demo-auditor/**/artifacts/**
+      - name: Attach Auditor Evidence to Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" "${AUDITOR_EVIDENCE_ARCHIVE}" --clobber
       - name: Attest Release Artifacts
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
         if: ${{ !(github.event.repository.private && github.event.repository.owner.type == 'User') }}

--- a/README.md
+++ b/README.md
@@ -405,9 +405,9 @@ export OPENAI_BASE_URL=http://localhost:8443/v1
 | `GET` | `/v1/records` | List records (with filters) |
 | `GET` | `/v1/records/{id}/proof` | Get Merkle inclusion proof |
 | `GET` | `/v1/proofs/{id}` | Get inclusion proof by proof ID |
-| `POST` | `/v1/verify` | Verify a DSSE envelope |
-| `POST` | `/v1/verify/record` | Verify record (`?profile=basic\|strict\|fips`) |
-| `POST` | `/v1/verify/bundle` | Verify an audit bundle |
+| `POST` | `/v1/verify` | Verify a DSSE envelope (`profile` query or `verification_profile` body) |
+| `POST` | `/v1/verify/record` | Verify record (`basic\|strict\|fips`) |
+| `POST` | `/v1/verify/bundle` | Verify an audit bundle (`profile` query or `verification_profile` body) |
 | `GET` | `/v1/ledger/checkpoint` | Get latest Merkle checkpoint |
 | `GET` | `/v1/ledger/checkpoints/latest` | Alias for latest signed checkpoint |
 | `GET` | `/v1/ledger/consistency` | Get consistency proof (`from`,`to`) |

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -111,7 +111,7 @@ print(result.valid)
 | `get(request_id)` | Retrieve a record by ID |
 | `list(tenant_id, after, before, limit, cursor)` | List records with filters |
 | `get_proof(request_id)` | Get Merkle inclusion proof |
-| `verify(envelope)` | Server-side DSSE verification |
+| `verify(envelope, verification_profile=None)` | Server-side DSSE verification (`basic`, `strict`, `fips`) |
 | `export(tenant_id, after, before, limit)` | Export audit bundle |
 | `health()` | Health check |
 | `checkpoint()` | Get latest Merkle checkpoint |

--- a/sdk/python/vaol/client.py
+++ b/sdk/python/vaol/client.py
@@ -80,9 +80,19 @@ class VAOLClient:
         resp.raise_for_status()
         return _decode_json_object(resp)
 
-    def verify(self, envelope: dict[str, Any]) -> dict[str, Any]:
+    def verify(
+        self,
+        envelope: dict[str, Any],
+        verification_profile: str | None = None,
+    ) -> dict[str, Any]:
         """Verify a DSSE envelope."""
-        resp = self._client.post("/v1/verify", json=envelope)
+        payload: Any = envelope
+        if verification_profile:
+            payload = {
+                "envelope": envelope,
+                "verification_profile": verification_profile,
+            }
+        resp = self._client.post("/v1/verify", json=payload)
         resp.raise_for_status()
         return _decode_json_object(resp)
 
@@ -198,9 +208,19 @@ class AsyncVAOLClient:
         resp.raise_for_status()
         return _decode_json_object(resp)
 
-    async def verify(self, envelope: dict[str, Any]) -> dict[str, Any]:
+    async def verify(
+        self,
+        envelope: dict[str, Any],
+        verification_profile: str | None = None,
+    ) -> dict[str, Any]:
         """Verify a DSSE envelope."""
-        resp = await self._client.post("/v1/verify", json=envelope)
+        payload: Any = envelope
+        if verification_profile:
+            payload = {
+                "envelope": envelope,
+                "verification_profile": verification_profile,
+            }
+        resp = await self._client.post("/v1/verify", json=payload)
         resp.raise_for_status()
         return _decode_json_object(resp)
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -32,7 +32,7 @@ const receipt = await client.append(record);
 console.log(`Record stored at sequence ${receipt.sequence_number}`);
 
 // Verify
-const result = await client.verify(receipt.envelope);
+const result = await client.verify(receipt.envelope, "strict");
 console.log(`Valid: ${result.valid}`);
 ```
 
@@ -69,7 +69,7 @@ const response = await openai.chat.completions.create({
 | `get(requestID)` | Get a record by request ID |
 | `list(options?)` | List records with filters |
 | `getProof(requestID)` | Get Merkle inclusion proof |
-| `verify(envelope)` | Verify a DSSE envelope |
+| `verify(envelope, verificationProfile?)` | Verify a DSSE envelope (`basic`, `strict`, `fips`) |
 | `checkpoint()` | Get latest Merkle checkpoint |
 | `exportBundle(options?)` | Export audit bundle |
 | `health()` | Health check |

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -4,6 +4,7 @@ import type {
   Receipt,
   VerificationResult,
   DSSEEnvelope,
+  VerificationProfile,
 } from "./types.js";
 
 export interface VAOLClientOptions {
@@ -90,8 +91,17 @@ export class VAOLClient {
   }
 
   /** Verify a single record or DSSE envelope. */
-  async verify(envelope: DSSEEnvelope): Promise<VerificationResult> {
-    return this.request<VerificationResult>("POST", "/v1/verify", envelope);
+  async verify(
+    envelope: DSSEEnvelope,
+    verificationProfile?: VerificationProfile
+  ): Promise<VerificationResult> {
+    if (!verificationProfile) {
+      return this.request<VerificationResult>("POST", "/v1/verify", envelope);
+    }
+    return this.request<VerificationResult>("POST", "/v1/verify", {
+      envelope,
+      verification_profile: verificationProfile,
+    });
   }
 
   /** Get the latest signed Merkle checkpoint. */

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -23,5 +23,6 @@ export type {
   DSSEEnvelope,
   DSSESignature,
   VerificationResult,
+  VerificationProfile,
   CheckResult,
 } from "./types.js";

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -166,6 +166,8 @@ export interface VerificationResult {
   error?: string;
 }
 
+export type VerificationProfile = "basic" | "strict" | "fips";
+
 export interface CheckResult {
   name: string;
   passed: boolean;


### PR DESCRIPTION
## Summary
- enforce verification profile selection via API request body (`verification_profile`) and reject conflicting query/body profile values
- support wrapped verify payloads for both envelope and bundle endpoints while keeping backward-compatible direct payload support
- add startup rebuild regressions for sparse sequence pagination and duplicate-sequence tamper rejection
- publish auditor evidence bundles in release workflow and attach them to tag releases
- expose optional verification profile in Python/TypeScript SDK verify clients and update docs

## Validation
- go test ./...
- cd sdk/python && ruff check vaol/ && mypy vaol/ && pytest tests/ -q
- cd sdk/typescript && npm run lint && npm test
- ./scripts/check_workflow_pins.sh