### PR TITLE
Verifier: enforce key revocations with effective timestamps

### DIFF
--- a/cmd/vaol-cli/main.go
+++ b/cmd/vaol-cli/main.go
@@ -84,6 +84,7 @@ func newVerifyCmd() *cobra.Command {
 func newVerifyBundleCmd() *cobra.Command {
 	var pubKeyPath string
 	var profile string
+	var revocationsFile string
 	var transcriptJSONPath string
 	var reportJSONPath string
 	var reportMarkdownPath string
@@ -110,6 +111,15 @@ func newVerifyBundleCmd() *cobra.Command {
 			}
 
 			v := verifier.New(verifiers...)
+			if revocationsFile != "" {
+				rules, err := verifier.LoadRevocationListFile(revocationsFile)
+				if err != nil {
+					return fmt.Errorf("loading revocations file: %w", err)
+				}
+				if err := v.SetRevocations(rules); err != nil {
+					return fmt.Errorf("applying revocations: %w", err)
+				}
+			}
 
 			selectedProfile := verifier.Profile(profile)
 			if selectedProfile == "" {
@@ -185,6 +195,7 @@ func newVerifyBundleCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&pubKeyPath, "public-key", "", "Ed25519 public key PEM for signature verification")
 	cmd.Flags().StringVar(&profile, "profile", string(verifier.ProfileBasic), "verification profile: basic, strict, fips")
+	cmd.Flags().StringVar(&revocationsFile, "revocations-file", "", "path to revocation list JSON with keyid/effective_at rules")
 	cmd.Flags().StringVar(&transcriptJSONPath, "transcript-json", "", "write deterministic verification transcript to JSON file")
 	cmd.Flags().StringVar(&reportJSONPath, "report-json", "", "write verification report JSON")
 	cmd.Flags().StringVar(&reportMarkdownPath, "report-markdown", "", "write verification report Markdown")
@@ -194,6 +205,7 @@ func newVerifyBundleCmd() *cobra.Command {
 func newVerifyRecordCmd() *cobra.Command {
 	var pubKeyPath string
 	var profile string
+	var revocationsFile string
 	cmd := &cobra.Command{
 		Use:   "record <file>",
 		Short: "Verify a single DSSE envelope",
@@ -219,6 +231,15 @@ func newVerifyRecordCmd() *cobra.Command {
 			}
 
 			v := verifier.New(verifiers...)
+			if revocationsFile != "" {
+				rules, err := verifier.LoadRevocationListFile(revocationsFile)
+				if err != nil {
+					return fmt.Errorf("loading revocations file: %w", err)
+				}
+				if err := v.SetRevocations(rules); err != nil {
+					return fmt.Errorf("applying revocations: %w", err)
+				}
+			}
 			selectedProfile := verifier.Profile(profile)
 			if selectedProfile == "" {
 				selectedProfile = verifier.ProfileBasic
@@ -254,6 +275,7 @@ func newVerifyRecordCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&pubKeyPath, "public-key", "", "Ed25519 public key PEM")
 	cmd.Flags().StringVar(&profile, "profile", string(verifier.ProfileBasic), "verification profile: basic, strict, fips")
+	cmd.Flags().StringVar(&revocationsFile, "revocations-file", "", "path to revocation list JSON with keyid/effective_at rules")
 	return cmd
 }
 

--- a/docs/auditor-guide.md
+++ b/docs/auditor-guide.md
@@ -105,10 +105,11 @@ The server returns the bundle as a JSON response. Save it to a file for offline 
 
 ```bash
 vaol verify bundle audit-bundle.json \
-  --public-key /path/to/vaol-signing.pub
+  --public-key /path/to/vaol-signing.pub \
+  --revocations-file /path/to/revocations.json
 ```
 
-The `--public-key` flag points to the Ed25519 public key PEM used by the VAOL server that signed the records. If your organization distributes the public key through a key management system, retrieve it from there.
+The `--public-key` flag points to the Ed25519 public key PEM used by the VAOL server that signed the records. If your organization distributes the public key through a key management system, retrieve it from there. The optional `--revocations-file` flag enforces compromised-key deny rules with RFC3339 effective timestamps.
 
 ### What the Verifier Checks
 
@@ -125,6 +126,8 @@ The verifier performs these checks on every record in the bundle:
 5. **Merkle inclusion** -- For each record, the verifier walks the inclusion proof (sibling hashes from leaf to root) and confirms the computed root matches the checkpoint root hash at the stated tree size.
 
 6. **Policy fields present** -- Every record must contain a `policy_context` with at least a `policy_decision` value (`allow`, `deny`, `allow_with_transform`, or `log_only`).
+
+7. **Key revocation enforcement (optional)** -- If a revocation list is supplied, every envelope signature `keyid` must be valid for the signature timestamp. Any key revoked at or before the signature time causes deterministic verification failure.
 
 ### Interpreting the Output
 
@@ -396,8 +399,8 @@ The raw model output is stored directly in the record. This mode should only be 
 | Task                        | Command                                                                 |
 |-----------------------------|-------------------------------------------------------------------------|
 | Export a bundle             | `vaol export --tenant <id> --after <date> --before <date> --output <file>` |
-| Verify a bundle             | `vaol verify bundle <file> --public-key <key.pub>`                      |
-| Verify a single envelope    | `vaol verify record <file> --public-key <key.pub>`                      |
+| Verify a bundle             | `vaol verify bundle <file> --public-key <key.pub> [--revocations-file <revocations.json>]` |
+| Verify a single envelope    | `vaol verify record <file> --public-key <key.pub> [--revocations-file <revocations.json>]` |
 | Inspect a record            | `vaol inspect <envelope-file>`                                          |
 | Generate a signing key pair | `vaol keys generate --output <dir>`                                     |
 

--- a/pkg/verifier/revocation.go
+++ b/pkg/verifier/revocation.go
@@ -1,0 +1,149 @@
+package verifier
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ogulcanaydogan/vaol/pkg/signer"
+)
+
+// RevocationRule blocks a key identifier at or after EffectiveAt.
+type RevocationRule struct {
+	KeyID       string    `json:"keyid"`
+	EffectiveAt time.Time `json:"-"`
+	Reason      string    `json:"reason,omitempty"`
+}
+
+// RevocationList is a file-backed rule set used by CLI and automation.
+type RevocationList struct {
+	Version     string               `json:"version,omitempty"`
+	GeneratedAt string               `json:"generated_at,omitempty"`
+	Revocations []RevocationListRule `json:"revocations"`
+}
+
+// RevocationListRule is the JSON-serializable form of a single revocation rule.
+type RevocationListRule struct {
+	KeyID       string `json:"keyid"`
+	EffectiveAt string `json:"effective_at"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type revocationWindow struct {
+	effectiveAt time.Time
+	reason      string
+}
+
+// ParseRevocationList parses and validates a revocation list JSON payload.
+func ParseRevocationList(raw []byte) ([]RevocationRule, error) {
+	var list RevocationList
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parsing revocations json: %w", err)
+	}
+
+	if len(list.Revocations) == 0 {
+		return nil, nil
+	}
+
+	out := make([]RevocationRule, 0, len(list.Revocations))
+	for i, item := range list.Revocations {
+		keyID := strings.TrimSpace(item.KeyID)
+		if keyID == "" {
+			return nil, fmt.Errorf("revocations[%d].keyid is required", i)
+		}
+		effective := strings.TrimSpace(item.EffectiveAt)
+		if effective == "" {
+			return nil, fmt.Errorf("revocations[%d].effective_at is required", i)
+		}
+		effectiveAt, err := time.Parse(time.RFC3339, effective)
+		if err != nil {
+			return nil, fmt.Errorf("revocations[%d].effective_at must be RFC3339: %w", i, err)
+		}
+		out = append(out, RevocationRule{
+			KeyID:       keyID,
+			EffectiveAt: effectiveAt.UTC(),
+			Reason:      strings.TrimSpace(item.Reason),
+		})
+	}
+	return out, nil
+}
+
+// LoadRevocationListFile reads and parses revocation rules from a JSON file.
+func LoadRevocationListFile(path string) ([]RevocationRule, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading revocations file: %w", err)
+	}
+	return ParseRevocationList(raw)
+}
+
+// SetRevocations replaces all revocation rules on the verifier.
+func (v *Verifier) SetRevocations(rules []RevocationRule) error {
+	compiled := make(map[string][]revocationWindow, len(rules))
+	for i, rule := range rules {
+		keyID := strings.TrimSpace(rule.KeyID)
+		if keyID == "" {
+			return fmt.Errorf("revocation rule %d has empty keyid", i)
+		}
+		if rule.EffectiveAt.IsZero() {
+			return fmt.Errorf("revocation rule %d has zero effective_at", i)
+		}
+		compiled[keyID] = append(compiled[keyID], revocationWindow{
+			effectiveAt: rule.EffectiveAt.UTC(),
+			reason:      strings.TrimSpace(rule.Reason),
+		})
+	}
+
+	for keyID := range compiled {
+		sort.Slice(compiled[keyID], func(i, j int) bool {
+			return compiled[keyID][i].effectiveAt.Before(compiled[keyID][j].effectiveAt)
+		})
+	}
+
+	v.revocations = compiled
+	return nil
+}
+
+func (v *Verifier) verifyRevocations(env *signer.Envelope, now time.Time) error {
+	if len(v.revocations) == 0 {
+		return nil
+	}
+
+	for i, sig := range env.Signatures {
+		keyID := strings.TrimSpace(sig.KeyID)
+		if keyID == "" {
+			continue
+		}
+
+		windows := v.revocations[keyID]
+		if len(windows) == 0 {
+			continue
+		}
+
+		evaluationTime := now.UTC()
+		if timestamp := strings.TrimSpace(sig.Timestamp); timestamp != "" {
+			parsed, err := time.Parse(time.RFC3339, timestamp)
+			if err != nil {
+				return fmt.Errorf("invalid signatures[%d].timestamp for revocation check: %w", i, err)
+			}
+			evaluationTime = parsed.UTC()
+		}
+
+		for _, window := range windows {
+			if evaluationTime.Before(window.effectiveAt) {
+				continue
+			}
+			msg := fmt.Sprintf("signature key revoked: keyid=%s effective_at=%s", keyID, window.effectiveAt.Format(time.RFC3339))
+			if window.reason != "" {
+				msg = fmt.Sprintf("%s reason=%s", msg, window.reason)
+			}
+			return errors.New(msg)
+		}
+	}
+
+	return nil
+}

--- a/pkg/verifier/revocation_test.go
+++ b/pkg/verifier/revocation_test.go
@@ -1,0 +1,52 @@
+package verifier
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRevocationListValid(t *testing.T) {
+	raw := []byte(`{
+		"version": "v1",
+		"generated_at": "2026-02-23T00:00:00Z",
+		"revocations": [
+			{
+				"keyid": "ed25519:abc123",
+				"effective_at": "2026-02-01T00:00:00Z",
+				"reason": "compromised"
+			}
+		]
+	}`)
+
+	rules, err := ParseRevocationList(raw)
+	if err != nil {
+		t.Fatalf("ParseRevocationList error: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("expected one rule, got %d", len(rules))
+	}
+	if rules[0].KeyID != "ed25519:abc123" {
+		t.Fatalf("unexpected keyid: %s", rules[0].KeyID)
+	}
+	if rules[0].Reason != "compromised" {
+		t.Fatalf("unexpected reason: %s", rules[0].Reason)
+	}
+	if rules[0].EffectiveAt.Format(time.RFC3339) != "2026-02-01T00:00:00Z" {
+		t.Fatalf("unexpected effective_at: %s", rules[0].EffectiveAt.Format(time.RFC3339))
+	}
+}
+
+func TestParseRevocationListRejectsBadTimestamp(t *testing.T) {
+	raw := []byte(`{
+		"revocations": [
+			{
+				"keyid": "ed25519:abc123",
+				"effective_at": "not-a-time"
+			}
+		]
+	}`)
+
+	if _, err := ParseRevocationList(raw); err == nil {
+		t.Fatal("expected ParseRevocationList to fail on invalid effective_at")
+	}
+}


### PR DESCRIPTION
## Summary
- add verifier-side key revocation enforcement using `keyid` + RFC3339 `effective_at` rules
- add revocation list parser/loader and `SetRevocations` API in verifier package
- add `--revocations-file` flag to `vaol verify bundle` and `vaol verify record`
- include `key_revocation` as an explicit verification check and mark bundle signature state invalid on revocation failures
- document revocation usage in README and auditor guide

## Validation
- `go test ./...`
- `cd sdk/python && ruff check vaol/ && mypy vaol/ && pytest tests/ -v`
- `cd sdk/typescript && npm ci && npm run lint && npm test`
- `./scripts/demo_auditor.sh`

## Notes
- CPU-only workflow preserved; no GPU dependency introduced.
- No DecisionRecord schema or REST API contract changes.
