### PR TITLE
chore: pin workflows to go 1.25.x to clear govulncheck stdlib alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
           version: v1.64.8
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: go test -race -cover ./...
 
   test-e2e-tamper:
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: go test -race ./tests/e2e ./tests/tamper -v
 
   test-python:
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: go test -bench=. -benchmem -count=1 ./pkg/merkle/... ./pkg/signer/... ./pkg/record/... | tee bench-results.txt
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: ./scripts/check_startup_restore_bench.sh
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
@@ -149,7 +149,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
       - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - run: gosec -quiet -exclude=G104,G117,G204,G304,G306,G704 -exclude-dir=gen ./...
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - run: go build ./cmd/vaol-server
       - run: go build ./cmd/vaol-cli
       - run: go build ./cmd/vaol-proxy
@@ -209,7 +209,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - name: Run reproducible auditor demo
         env:
           VAOL_DEMO_KEEP_STACK: "0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: "1.24.13"
+          go-version: "1.25.x"
       - name: Login to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI and release workflows now pin `go-version: "1.25.x"` (was `"1.24.13"`); pulls in stdlib security fixes from Go 1.25.9 / 1.25.10 that `govulncheck` (`golang.org/x/vuln/cmd/govulncheck@v1.1.4`) flagged on the Security Scan job. `go.mod` remains on `go 1.24.0` so the module consumer floor is unchanged.
+
 ## [0.2.29] - 2026-05-07
 
 ### Added

--- a/deploy/docker/Dockerfile.proxy
+++ b/deploy/docker/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/deploy/docker/Dockerfile.server
+++ b/deploy/docker/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- Security Scan job has been red on `main` since 2026-05-07 because `govulncheck v1.1.4` flags stdlib vulnerabilities (`GO-2026-4982`, `4980`, `4971`, `4947`, `4946`, `4918`, `4870`, `4865`, `4762`, `4603`, and more) all fixed in Go 1.25.9 / 1.25.10, while the nine `setup-go` pins were still on `"1.24.13"`.
- Bumps all nine pins (`8 x ci.yml`, `1 x release.yml`) from `"1.24.13"` to floating `"1.25.x"` so future 1.25-line security backports auto-apply without further workflow churn.
- `go.mod` deliberately left at `go 1.24.0` -- the toolchain bump is CI-side only; the module consumer floor is unchanged.

## Test plan

- [ ] Security Scan job shows `SUCCESS` (govulncheck clean against Go 1.25.x stdlib)
- [ ] All other CI jobs (lint, test, build, govulncheck, gosec, trivy) pass unchanged
- [ ] `go.mod` diff is empty -- no consumer-floor change