### PR TITLE
refactor: clear staticcheck QF1012 and QF1001 in report and validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI and release workflows now pin `go-version: "1.25.x"` (was `"1.24.13"`); pulls in stdlib security fixes from Go 1.25.9 / 1.25.10 that `govulncheck` (`golang.org/x/vuln/cmd/govulncheck@v1.1.4`) flagged on the Security Scan job. `go.mod` remains on `go 1.24.0` so the module consumer floor is unchanged.
 - `golangci-lint-action` bumped from v6.5.2 to v7.0.1 (`9fae48ac`) and lint binary from `v1.64.8` to `v2.12.2`; `.golangci.yml` migrated to v2 schema. Quickfix and style checks `QF1001`, `QF1011`, `QF1012`, `ST1005`, `ST1023` deferred to a follow-up `refactor:`/`style:` PR so this bump stays scope-clean.
 
+### Refactored
+
+- `pkg/verifier/report.go` Markdown report builder now uses `fmt.Fprintf(&b, ...)` directly against the `strings.Builder` instead of the `b.WriteString(fmt.Sprintf(...))` double-allocation pattern (10 call sites; staticcheck `QF1012`). Output is identical.
+- `pkg/record/validate.go` hex-character check rewritten via De Morgan's law from `!((digit) || (lowercase hex))` to `(not digit) && (not lowercase hex)` (staticcheck `QF1001`). Equivalent behaviour, idiomatic per the v2 linter set.
+
 ## [0.2.29] - 2026-05-07
 
 ### Added

--- a/pkg/record/validate.go
+++ b/pkg/record/validate.go
@@ -145,7 +145,7 @@ func validateHashFormat(hash, fieldName string) error {
 		return fmt.Errorf("%s: invalid hash prefix (expected 'sha256:')", fieldName)
 	}
 	for _, c := range hash[7:] {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			return fmt.Errorf("%s: invalid hex character in hash: %c", fieldName, c)
 		}
 	}

--- a/pkg/verifier/report.go
+++ b/pkg/verifier/report.go
@@ -32,30 +32,30 @@ func (r *Report) ToJSON() ([]byte, error) {
 func (r *Report) ToMarkdown() string {
 	var b strings.Builder
 
-	b.WriteString(fmt.Sprintf("# %s\n\n", r.Title))
-	b.WriteString(fmt.Sprintf("**Generated:** %s\n\n", r.Generated.Format(time.RFC3339)))
+	fmt.Fprintf(&b, "# %s\n\n", r.Title)
+	fmt.Fprintf(&b, "**Generated:** %s\n\n", r.Generated.Format(time.RFC3339))
 
 	b.WriteString("## Summary\n\n")
 	b.WriteString("| Metric | Value |\n")
 	b.WriteString("|--------|-------|\n")
-	b.WriteString(fmt.Sprintf("| Total records | %d |\n", r.Bundle.TotalRecords))
-	b.WriteString(fmt.Sprintf("| Valid records | %d |\n", r.Bundle.ValidRecords))
-	b.WriteString(fmt.Sprintf("| Invalid records | %d |\n", r.Bundle.InvalidRecords))
-	b.WriteString(fmt.Sprintf("| Hash chain | %s |\n", passFailIcon(r.Bundle.ChainIntact)))
-	b.WriteString(fmt.Sprintf("| Merkle proofs | %s |\n", passFailIcon(r.Bundle.MerkleValid)))
-	b.WriteString(fmt.Sprintf("| Signatures | %s |\n", passFailIcon(r.Bundle.SignaturesValid)))
-	b.WriteString(fmt.Sprintf("| Schema | %s |\n", passFailIcon(r.Bundle.SchemaValid)))
-	b.WriteString(fmt.Sprintf("| Manifest | %s |\n", passFailIcon(r.Bundle.ManifestValid)))
+	fmt.Fprintf(&b, "| Total records | %d |\n", r.Bundle.TotalRecords)
+	fmt.Fprintf(&b, "| Valid records | %d |\n", r.Bundle.ValidRecords)
+	fmt.Fprintf(&b, "| Invalid records | %d |\n", r.Bundle.InvalidRecords)
+	fmt.Fprintf(&b, "| Hash chain | %s |\n", passFailIcon(r.Bundle.ChainIntact))
+	fmt.Fprintf(&b, "| Merkle proofs | %s |\n", passFailIcon(r.Bundle.MerkleValid))
+	fmt.Fprintf(&b, "| Signatures | %s |\n", passFailIcon(r.Bundle.SignaturesValid))
+	fmt.Fprintf(&b, "| Schema | %s |\n", passFailIcon(r.Bundle.SchemaValid))
+	fmt.Fprintf(&b, "| Manifest | %s |\n", passFailIcon(r.Bundle.ManifestValid))
 	b.WriteString("\n")
 
 	if r.Bundle.InvalidRecords > 0 {
 		b.WriteString("## Failures\n\n")
 		for _, res := range r.Bundle.Results {
 			if !res.Valid {
-				b.WriteString(fmt.Sprintf("### Record %s\n\n", res.RequestID))
+				fmt.Fprintf(&b, "### Record %s\n\n", res.RequestID)
 				for _, check := range res.Checks {
 					if !check.Passed {
-						b.WriteString(fmt.Sprintf("- **%s**: %s\n", check.Name, check.Error))
+						fmt.Fprintf(&b, "- **%s**: %s\n", check.Name, check.Error)
 					}
 				}
 				b.WriteString("\n")
@@ -63,7 +63,7 @@ func (r *Report) ToMarkdown() string {
 		}
 	}
 
-	b.WriteString(fmt.Sprintf("## Conclusion\n\n%s\n", r.Bundle.Summary))
+	fmt.Fprintf(&b, "## Conclusion\n\n%s\n", r.Bundle.Summary)
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

- `pkg/verifier/report.go` — rewrite 10 `b.WriteString(fmt.Sprintf(...))` calls as `fmt.Fprintf(&b, ...)` (staticcheck QF1012). Drops the intermediate string allocation; output is byte-identical.
- `pkg/record/validate.go:148` — apply De Morgan's law so the negated disjunction becomes a conjunction of negations (staticcheck QF1001). Equivalent behaviour, matches the v2 linter set's preferred form.
- CHANGELOG.md — entry under `### Refactored`.

## Context

Closes 2 of the 5 staticcheck-v2 check families the prior `chore: migrate golangci-lint to v2` PR explicitly deferred. Companion `style:` PR will follow for ST1005 + ST1023.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/verifier/... ./pkg/record/...` green
- [ ] CI `Lint (Go)` job green after v2 linter runs against the refactored files