### PR TITLE
style: lowercase Rekor error strings and drop redundant json.Number type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CI and release workflows now pin `go-version: "1.25.x"` (was `"1.24.13"`); pulls in stdlib security fixes from Go 1.25.9 / 1.25.10 that `govulncheck` (`golang.org/x/vuln/cmd/govulncheck@v1.1.4`) flagged on the Security Scan job. `go.mod` remains on `go 1.24.0` so the module consumer floor is unchanged.
 - `golangci-lint-action` bumped from v6.5.2 to v7.0.1 (`9fae48ac`) and lint binary from `v1.64.8` to `v2.12.2`; `.golangci.yml` migrated to v2 schema. Quickfix and style checks `QF1001`, `QF1011`, `QF1012`, `ST1005`, `ST1023` deferred to a follow-up `refactor:`/`style:` PR so this bump stays scope-clean.
+- Sigstore/Rekor error strings in `pkg/signer/sigstore.go` and `pkg/verifier/rekor.go` (4 sites) lowercased so they compose cleanly when wrapped (staticcheck `ST1005`).
+- `pkg/auth/jwt.go` numeric-string unix time path drops the redundant type annotation on the `json.Number` conversion (staticcheck `ST1023`).
 
 ## [0.2.29] - 2026-05-07
 

--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -435,7 +435,7 @@ func parseNumericDate(v any) (time.Time, bool) {
 			return time.Time{}, false
 		}
 		// Accept numeric unix time as string.
-		var num json.Number = json.Number(t)
+		num := json.Number(t)
 		n, err := num.Int64()
 		if err != nil {
 			return time.Time{}, false

--- a/pkg/signer/sigstore.go
+++ b/pkg/signer/sigstore.go
@@ -163,7 +163,7 @@ func (s *SigstoreSigner) submitRekorEntry(ctx context.Context, payload []byte, s
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("Rekor status %d: %s", resp.StatusCode, string(body))
+		return "", fmt.Errorf("rekor status %d: %s", resp.StatusCode, string(body))
 	}
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -186,7 +186,7 @@ func (s *SigstoreSigner) submitRekorEntry(ctx context.Context, payload []byte, s
 		}
 	}
 
-	return "", fmt.Errorf("Rekor response missing entry ID")
+	return "", fmt.Errorf("rekor response missing entry ID")
 }
 
 func mintEphemeralCert(identity string, pub ed25519.PublicKey, priv ed25519.PrivateKey) ([]byte, error) {
@@ -399,7 +399,7 @@ func (v *SigstoreVerifier) verifyRekorEntry(ctx context.Context, entryID string)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("Rekor entry lookup failed: status=%d body=%s", resp.StatusCode, string(body))
+		return fmt.Errorf("rekor entry lookup failed: status=%d body=%s", resp.StatusCode, string(body))
 	}
 	return nil
 }

--- a/pkg/verifier/rekor.go
+++ b/pkg/verifier/rekor.go
@@ -59,7 +59,7 @@ func (c *HTTPRekorClient) VerifyEntry(ctx context.Context, baseURL, entryID stri
 		return fmt.Errorf("reading Rekor response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Rekor entry lookup failed: status=%d body=%s", resp.StatusCode, string(body))
+		return fmt.Errorf("rekor entry lookup failed: status=%d body=%s", resp.StatusCode, string(body))
 	}
 
 	payloadHash, err := extractRekorPayloadHash(body)


### PR DESCRIPTION
## Summary

- `pkg/signer/sigstore.go` (3 sites) + `pkg/verifier/rekor.go` (1 site) — lowercase "Rekor" → "rekor" in returned error strings (staticcheck `ST1005`). Composes cleanly when wrapped via `fmt.Errorf("verify foo: %w", err)`.
- `pkg/auth/jwt.go:438` — `var num json.Number = json.Number(t)` → `num := json.Number(t)` (staticcheck `ST1023`). Type is already inferable from the conversion.
- CHANGELOG.md — two entries under `### Changed`.

## Context

Closes 2 of the remaining 3 staticcheck-v2 check families deferred by the golangci-lint v2 migration. `noctx` on `cmd/vaol-server/main.go:302` (server bootstrap `net.Listen`) is deliberately kept open as a separate follow-up since the listener has no cancellation requirement.

Companion to PR #45 (refactor: QF1012 + QF1001).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/signer/... ./pkg/verifier/... ./pkg/auth/...` green
- [x] No tests or callers depend on capitalized "Rekor" prefix (`grep -rn 'Rekor status\|Rekor response\|Rekor entry'` returns 0 hits after the change)
- [ ] CI `Lint (Go)` job no longer flags ST1005/ST1023 in these files