### PR TITLE
docs: add community health files

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers
+
+| Maintainer | GitHub |
+|---|---|
+| Ogulcan Aydogan | [@ogulcanaydogan](https://github.com/ogulcanaydogan) |
+
+## Governance
+
+This project currently operates under a single-maintainer model. The maintainer
+reviews and merges contributions, triages issues, cuts releases, and upholds the
+Code of Conduct. Larger proposals (breaking changes, new major features) should
+start as an issue for discussion before implementation.
+
+## Contact
+
+- General and contribution questions: open a GitHub issue.
+- Security reports: see [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
Adds standard community/governance docs (MAINTAINERS.md) to match the flagship-repo standard.